### PR TITLE
Code refactor

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,7 @@ pipeline:
   test:
     image: python:3.7.1-alpine
     commands:
+      - apk add --no-cache libffi-dev build-base
       - pip3 install --upgrade pip setuptools wheel
       - pip3 install pytest==4.2.0 pytest-cov==2.6.1 pytest-mock==1.10.1 moto==1.3.7
       - pip3 install -e .

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ pipeline:
     image: python:3.7.1-alpine
     commands:
       - pip3 install --upgrade pip setuptools wheel
-      - pip3 install pytest==4.2.0 pytest-cov==2.6.1 pytest-mock==1.10.1
+      - pip3 install pytest==4.2.0 pytest-cov==2.6.1 pytest-mock==1.10.1 moto==1.3.7
       - pip3 install -e .
       - pytest -p no:warnings --cov=target_kinesis tests/
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,9 +14,9 @@ pipeline:
     image: python:3.7.1-alpine
     commands:
       - pip3 install --upgrade pip setuptools wheel
-      - pip3 install pytest
+      - pip3 install pytest==4.2.0 pytest-cov==2.6.1 pytest-mock==1.10.1
       - pip3 install -e .
-      - pytest -p no:warnings
+      - pytest -p no:warnings --cov=target_kinesis tests/
     when:
       event:
         - push

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ pipeline:
   test:
     image: python:3.7.1-alpine
     commands:
-      - apk add --no-cache libffi-dev build-base
+      - apk add --no-cache libffi-dev openssl-dev build-base
       - pip3 install --upgrade pip setuptools wheel
       - pip3 install pytest==4.2.0 pytest-cov==2.6.1 pytest-mock==1.10.1 moto==1.3.7
       - pip3 install -e .

--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ To run `target-kinesis` with the configuration file, use this command:
 [Singer Tap]: https://singer.io
 [Mac]: http://docs.python-guide.org/en/latest/starting/install3/osx/
 [Ubuntu]: https://www.digitalocean.com/community/tutorials/how-to-install-python-3-and-set-up-a-local-programming-environment-on-ubuntu-16-04
+
+### Run test suite
+
+```
+pytest -p no:warnings --cov=target_kinesis tests/test_target.py --cov-report=html
+```

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
             'pylint==2.1.1',
             'pytest==4.2.0',
             'pytest-cov==2.6.1',
-            'pytest-mock==1.10.1'
+            'pytest-mock==1.10.1',
+            'moto==1.3.7'
         ]
     },
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
     extras_require={
         'dev': [
             'pylint==2.1.1',
-            'pytest==4.2.0'
+            'pytest==4.2.0',
+            'pytest-cov==2.6.1'
         ]
     },
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
         'dev': [
             'pylint==2.1.1',
             'pytest==4.2.0',
-            'pytest-cov==2.6.1'
+            'pytest-cov==2.6.1',
+            'pytest-mock==1.10.1'
         ]
     },
     entry_points="""

--- a/target_kinesis/__init__.py
+++ b/target_kinesis/__init__.py
@@ -4,24 +4,7 @@ import argparse
 import json
 import io
 
-from .target import *
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-c', '--config', help='Config file')
-    args = parser.parse_args()
-
-    if args.config:
-        with open(args.config) as input:
-            config = json.load(input)
-    else:
-        config = {}
-
-    input = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
-    state = persist_lines(config, input)
-
-    emit_state(state)
-    logger.debug("Exiting normally")
+from .target import main
 
 
 if __name__ == '__main__':

--- a/target_kinesis/firehose.py
+++ b/target_kinesis/firehose.py
@@ -2,10 +2,8 @@ import boto3
 import json
 import singer
 
-logger = singer.get_logger()
 
-
-def setup_client(config):
+def firehose_setup_client(config):
     aws_access_key_id = config.get("aws_access_key_id")
     aws_secret_access_key = config.get("aws_secret_access_key")
     region_name = config.get("region_name", "eu-west-2")
@@ -18,12 +16,14 @@ def setup_client(config):
     )
 
 
-def deliver(client, stream_name, records):
+def firehose_deliver(client, stream_name, records):
+
+    logger = singer.get_logger()
 
     if len(records) == 0:
-        raise EmptyContentException
+        raise Exception("Record list is empty")
 
-    if type(records) == 'dict':
+    if isinstance(records, dict):
         records = [records]
 
     encode_records = map(lambda x: json.dumps(x), records)
@@ -34,8 +34,6 @@ def deliver(client, stream_name, records):
         Record={'Data': payload}
     )
 
+    logger.info(response)
     return response
 
-
-class EmptyContentException(Exception):
-    pass

--- a/target_kinesis/firehose.py
+++ b/target_kinesis/firehose.py
@@ -4,25 +4,38 @@ import singer
 
 logger = singer.get_logger()
 
-def deliver(config, record):
-  stream_name = config.get("stream_name")
-  aws_access_key_id = config.get("aws_access_key_id")
-  aws_secret_access_key = config.get("aws_secret_access_key")
-  region_name = config.get("region_name", "eu-west-2")
 
-  client = boto3.client(
-    'firehose',
-    aws_access_key_id=aws_access_key_id,
-    aws_secret_access_key=aws_secret_access_key,
-    region_name=region_name
-  )
+def setup_client(config):
+    aws_access_key_id = config.get("aws_access_key_id")
+    aws_secret_access_key = config.get("aws_secret_access_key")
+    region_name = config.get("region_name", "eu-west-2")
 
-  response = client.put_record(
-    DeliveryStreamName=stream_name,
-    Record={
-      'Data': json.dumps(record) + "\n"
-    }
-  )
+    return boto3.client(
+        'firehose',
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        region_name=region_name
+    )
 
-  logger.info(response)
 
+def deliver(client, stream_name, records):
+
+    if len(records) == 0:
+        raise EmptyContentException
+
+    if type(records) == 'dict':
+        records = [records]
+
+    encode_records = map(lambda x: json.dumps(x), records)
+    payload = "\n".join(encode_records)
+
+    response = client.put_record(
+        DeliveryStreamName=stream_name,
+        Record={'Data': payload}
+    )
+
+    return response
+
+
+class EmptyContentException(Exception):
+    pass

--- a/target_kinesis/kinesis.py
+++ b/target_kinesis/kinesis.py
@@ -1,22 +1,35 @@
 import boto3
 import json
+import singer
 
-def deliver(config, record):
-  stream_name = config.get("stream_name")
-  partition_key = config.get("partition_key", "id")
-  aws_access_key_id = config.get("aws_access_key_id")
-  aws_secret_access_key = config.get("aws_secret_access_key")
-  region_name = config.get("region_name")
 
-  client = boto3.client(
-    'kinesis',
-    aws_access_key_id=aws_access_key_id,
-    aws_secret_access_key=aws_secret_access_key,
-    region_name=region_name
-  )
+def kinesis_setup_client(config):
+    aws_access_key_id = config.get("aws_access_key_id")
+    aws_secret_access_key = config.get("aws_secret_access_key")
+    region_name = config.get("region_name")
 
-  response = client.put_record(
-    StreamName=stream_name,
-    Data=json.dumps(record).encode(),
-    PartitionKey=record[partition_key]
-  )
+    return boto3.client(
+        'kinesis',
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        region_name=region_name
+    )
+
+
+def kinesis_deliver(client, stream_name, partition_key, records):
+
+    logger = singer.get_logger()
+
+    if len(records) == 0:
+        raise Exception("Record list is empty")
+
+    if isinstance(records, dict):
+        records = [records]
+
+    response = client.put_record(
+        StreamName=stream_name,
+        Data=json.dumps(records).encode(),
+        PartitionKey=records[0][partition_key]
+    )
+    logger.info(response)
+    return response

--- a/target_kinesis/kinesis.py
+++ b/target_kinesis/kinesis.py
@@ -6,7 +6,7 @@ import singer
 def kinesis_setup_client(config):
     aws_access_key_id = config.get("aws_access_key_id")
     aws_secret_access_key = config.get("aws_secret_access_key")
-    region_name = config.get("region_name")
+    region_name = config.get("region_name", "eu-west-2")
 
     return boto3.client(
         'kinesis',

--- a/target_kinesis/target.py
+++ b/target_kinesis/target.py
@@ -63,15 +63,14 @@ def handle_schema(o, schemas, validators, key_properties, line):
     if 'stream' not in o:
         raise Exception(
             "Line is missing required key 'stream': {}".format(line))
-        stream = o['stream']
-        schemas[stream] = o['schema']
-        validators[stream] = Draft4Validator(o['schema'])
-        if 'key_properties' not in o:
-            raise Exception("key_properties field is required")
-        key_properties[stream] = o['key_properties']
-    else:
-        raise Exception("Unknown message type {} in message {}"
-                        .format(o['type'], o))
+    stream = o['stream']
+    schemas[stream] = o['schema']
+    validators[stream] = Draft4Validator(o['schema'])
+    if 'key_properties' not in o:
+        raise Exception("key_properties field is required")
+    key_properties[stream] = o['key_properties']
+
+    return schemas, validators, key_properties
 
 
 def persist_lines(config, lines):
@@ -93,6 +92,9 @@ def persist_lines(config, lines):
             state = handle_state(o)
         elif t == 'SCHEMA':
             handle_schema(o, schemas, validators, key_properties, line)
+        else:
+            raise Exception(
+                "Unknown message type {} in message {}".format(o['type'], o))
 
     return state
 

--- a/target_kinesis/target.py
+++ b/target_kinesis/target.py
@@ -18,6 +18,7 @@ from .firehose import deliver as deliver_to_firehose
 
 logger = singer.get_logger()
 
+
 def emit_state(state):
     if state is not None:
         line = json.dumps(state)
@@ -25,15 +26,54 @@ def emit_state(state):
         sys.stdout.write("{}\n".format(line))
         sys.stdout.flush()
 
-def flatten(d, parent_key='', sep='__'):
-    items = []
-    for k, v in d.items():
-        new_key = parent_key + sep + k if parent_key else k
-        if isinstance(v, collections.MutableMapping):
-            items.extend(flatten(v, new_key, sep=sep).items())
-        else:
-            items.append((new_key, str(v) if type(v) is list else v))
-    return dict(items)
+
+def decode_line(line):
+    try:
+        o = json.loads(line)
+    except json.decoder.JSONDecodeError:
+        logger.error("Unable to parse:\n{}".format(line))
+        raise
+    return o
+
+
+def get_line_type(decode_line, line):
+    if 'type' not in decode_line:
+        raise Exception(
+            "Line is missing required key 'type': {}".format(line))
+    return decode_line['type']
+
+
+def handle_record(o, schemas, line, config, schemas, validators):
+    if 'stream' not in o:
+        raise Exception(
+            "Line is missing required key 'stream': {}".format(line))
+    if o['stream'] not in schemas:
+        raise Exception(
+            "A record for stream {} was encountered before a corresponding schema".format(o['stream']))
+    validate_record(o['stream'], o['record'], schemas, validators)
+    deliver_record(config, o['record'])
+    return None
+
+
+def handle_state(o):
+    logger.debug('Setting state to {}'.format(o['value']))
+    return o['value']
+
+
+def handle_schema(o, stream, schemas, validators, key_properties):
+    if 'stream' not in o:
+        raise Exception(
+            "Line is missing required key 'stream': {}".format(line))
+        stream = o['stream']
+        schemas[stream] = o['schema']
+        validators[stream] = Draft4Validator(o['schema'])
+        if 'key_properties' not in o:
+            raise Exception("key_properties field is required")
+        key_properties[stream] = o['key_properties']
+    else:
+        raise Exception("Unknown message type {} in message {}"
+                        .format(o['type'], o))
+
 
 def persist_lines(config, lines):
     state = None
@@ -41,56 +81,26 @@ def persist_lines(config, lines):
     key_properties = {}
     headers = {}
     validators = {}
-
     now = datetime.now().strftime('%Y%m%dT%H%M%S')
-
-    # Loop over lines from stdin
     for line in lines:
-        try:
-            o = json.loads(line)
-        except json.decoder.JSONDecodeError:
-            logger.error("Unable to parse:\n{}".format(line))
-            raise
-
-        if 'type' not in o:
-            raise Exception("Line is missing required key 'type': {}".format(line))
-        t = o['type']
-
+        o = decode_line(line)
+        t = get_line_type(o, line)
         if t == 'RECORD':
-            if 'stream' not in o:
-                raise Exception("Line is missing required key 'stream': {}".format(line))
-            if o['stream'] not in schemas:
-                raise Exception("A record for stream {} was encountered before a corresponding schema".format(o['stream']))
-
-            # FIXME: the schema is fake, uncomment when available
-            # schema = schemas[o['stream']]
-
-            # FIXME: record validation fails because the schema is fake
-            # validators[o['stream']].validate(o['record'])
-
-            # If the record needs to be flattened, uncomment this line
-            # flattened_record = flatten(o['record'])
-
-            deliver_record(config, o['record'])
-
-            state = None
+            state = handle_record(o, schemas, line, schemas, validators)
         elif t == 'STATE':
-            logger.debug('Setting state to {}'.format(o['value']))
-            state = o['value']
+            state = handle_state(o)
         elif t == 'SCHEMA':
-            if 'stream' not in o:
-                raise Exception("Line is missing required key 'stream': {}".format(line))
-            stream = o['stream']
-            schemas[stream] = o['schema']
-            validators[stream] = Draft4Validator(o['schema'])
-            if 'key_properties' not in o:
-                raise Exception("key_properties field is required")
-            key_properties[stream] = o['key_properties']
-        else:
-            raise Exception("Unknown message type {} in message {}"
-                            .format(o['type'], o))
-
+            handle_schema(o, stream, schemas, validators, key_properties)
     return state
+
+
+def validate_record(stream, record, schemas, validator):
+    pass
+    # FIXME: the schema is fake, uncomment when available
+    # schema = schemas[stream]
+
+    # FIXME: record validation fails because the schema is fake
+    # validators[stream].validate(record)
 
 
 def deliver_record(config, record):
@@ -98,4 +108,28 @@ def deliver_record(config, record):
     if is_firehose:
         deliver_to_firehose(config, record)
     else:
-        deliver_to_kinesis(config, record)
+        pass
+        # deliver_to_kinesis(config, record)
+
+
+def load_config(config_filename):
+    if config_filename:
+        with open(config_filename) as input:
+            config = json.load(input)
+    else:
+        config = {}
+    return config
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config', help='Config file')
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+
+    input = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+    state = persist_lines(config, input)
+    emit_state(state)
+
+    logger.debug("Exiting normally")

--- a/tests/test_firehose.py
+++ b/tests/test_firehose.py
@@ -82,7 +82,7 @@ def test_deliver_raise_on_nonexistent_stream():
 @mock_kinesis
 def test_setup_client_firehose():
     config = {
-        "region": 'us-east-1',
+        "region_name": 'us-east-1',
         "aws_access_key_id": 'FAKE_AWS_ACCESS_KEY_ID',
         "aws_secret_access_key": 'FAKE_AWS_SECRET_ACCESS_KEY'
     }

--- a/tests/test_firehose.py
+++ b/tests/test_firehose.py
@@ -1,0 +1,66 @@
+from target_kinesis.firehose import deliver
+from target_kinesis.firehose import EmptyContentException
+
+import boto3
+from moto import mock_kinesis
+
+FAKE_STREAM_NAME = "test-stream"
+
+
+def setup_connection():
+    return boto3.client(
+        'firehose',
+        region_name='us-east-1',
+        aws_access_key_id='FAKE_AWS_ACCESS_KEY_ID',
+        aws_secret_access_key='FAKE_AWS_SECRET_ACCESS_KEY'
+    )
+
+
+def create_stream(client, stream_name):
+    client.create_delivery_stream(
+        DeliveryStreamName=stream_name,
+        S3DestinationConfiguration={
+            'RoleARN': 'arn:aws:iam::123456789012:role/firehose_test_role',
+            'BucketARN': 'arn:aws:s3:::kinesis-test',
+            'Prefix': 'myFolder/',
+            'BufferingHints': {'SizeInMBs': 123, 'IntervalInSeconds': 124},
+            'CompressionFormat': 'UNCOMPRESSED',
+        }
+    )
+
+
+@mock_kinesis
+def test_deliver_single_record():
+    client = setup_connection()
+    create_stream(client, FAKE_STREAM_NAME)
+
+    data = {"example": "content"}
+
+    response = deliver(client, FAKE_STREAM_NAME, data)
+    assert response['ResponseMetadata']['HTTPStatusCode'] is 200
+
+@mock_kinesis
+def test_deliver_multiple_records():
+    client = setup_connection()
+    create_stream(client, FAKE_STREAM_NAME)
+
+    data = [
+        {"example": "content1"}, 
+        {"example": "content2"}
+    ]
+
+    response = deliver(client, FAKE_STREAM_NAME, data)
+    assert response['ResponseMetadata']['HTTPStatusCode'] is 200
+
+@mock_kinesis
+def test_deliver_raise_on_empty_dataset():
+    client = setup_connection()
+    create_stream(client, FAKE_STREAM_NAME)
+
+    data = []
+
+    try:
+        deliver(client, FAKE_STREAM_NAME, data)
+        assert False
+    except EmptyContentException:
+        assert True

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -1,4 +1,96 @@
-# from target_kinesis import kinesis
+from target_kinesis.kinesis import *
 
-def test_answer():
-    assert True
+import boto3
+from moto import mock_kinesis
+
+FAKE_STREAM_NAME = "test-stream"
+PARTITION_KEY = "id"
+
+
+def setup_connection():
+    return boto3.client(
+        'kinesis',
+        region_name='us-east-1',
+        aws_access_key_id='FAKE_AWS_ACCESS_KEY_ID',
+        aws_secret_access_key='FAKE_AWS_SECRET_ACCESS_KEY'
+    )
+
+
+def create_stream(client, stream_name):
+    client.create_stream(StreamName=stream_name, ShardCount=1)
+
+
+@mock_kinesis
+def test_deliver_single_record():
+    client = setup_connection()
+    create_stream(client, FAKE_STREAM_NAME)
+
+    data = {"id": "1", "example": "content"}
+
+    response = kinesis_deliver(client, FAKE_STREAM_NAME, PARTITION_KEY, data)
+    assert response['ResponseMetadata']['HTTPStatusCode'] is 200
+
+@mock_kinesis
+def test_deliver_multiple_records():
+    client = setup_connection()
+    create_stream(client, FAKE_STREAM_NAME)
+
+    data = [
+        {"id": "1", "example": "content1"}, 
+        {"id": "2", "example": "content2"}
+    ]
+
+    response = kinesis_deliver(client, FAKE_STREAM_NAME, PARTITION_KEY, data)
+    assert response['ResponseMetadata']['HTTPStatusCode'] is 200
+
+@mock_kinesis
+def test_deliver_raise_on_partition_key_missing():
+    client = setup_connection()
+    create_stream(client, FAKE_STREAM_NAME)
+
+    data = {"example": "content"}
+
+    try:
+        kinesis_deliver(client, FAKE_STREAM_NAME, PARTITION_KEY, data)
+        assert False
+    except Exception:
+        assert True
+
+@mock_kinesis
+def test_deliver_raise_on_empty_dataset():
+    client = setup_connection()
+    create_stream(client, FAKE_STREAM_NAME)
+
+    data = []
+
+    try:
+        kinesis_deliver(client, FAKE_STREAM_NAME, PARTITION_KEY, data)
+        assert False
+    except Exception:
+        assert True
+
+
+@mock_kinesis
+def test_deliver_raise_on_nonexistent_stream():
+    client = setup_connection()
+    create_stream(client, FAKE_STREAM_NAME)
+
+    data = {"example": "content"}
+
+    try:
+        kinesis_deliver(client, 'another-name', PARTITION_KEY, data)
+        assert False
+    except Exception:
+        assert True
+
+
+@mock_kinesis
+def test_setup_client_kinesis():
+    config = {
+        "region": 'us-east-1',
+        "aws_access_key_id": 'FAKE_AWS_ACCESS_KEY_ID',
+        "aws_secret_access_key": 'FAKE_AWS_SECRET_ACCESS_KEY'
+    }
+    client = kinesis_setup_client(config)
+    print(client)
+    assert client.__class__.__name__ == "Kinesis"

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -1,0 +1,4 @@
+# from target_kinesis import kinesis
+
+def test_answer():
+    assert True

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -87,7 +87,7 @@ def test_deliver_raise_on_nonexistent_stream():
 @mock_kinesis
 def test_setup_client_kinesis():
     config = {
-        "region": 'us-east-1',
+        "region_name": 'us-east-1',
         "aws_access_key_id": 'FAKE_AWS_ACCESS_KEY_ID',
         "aws_secret_access_key": 'FAKE_AWS_SECRET_ACCESS_KEY'
     }

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,4 +1,38 @@
-from target_kinesis import *
+import json
+from target_kinesis.target import *
 
-def test_answer():
-    assert True
+# decode_line
+
+
+def test_decode_line_well_formed():
+    sample_object = {"example": "content"}
+    o = decode_line(json.dumps(sample_object))
+    assert isinstance(o, dict)
+    assert "example" in o
+    assert o["example"] == sample_object["example"]
+
+
+def test_decode_line_malformed():
+    sample_line = '{"example": "content"'
+    try:
+        decode_line(sample_line)
+        assert False
+    except json.decoder.JSONDecodeError:
+        assert True
+
+# get_line_type
+
+
+def test_get_line_type_present():
+    sample_object = {"type": "SCHEMA"}
+    t = get_line_type(sample_object, json.dumps(sample_object))
+    assert t == sample_object["type"]
+
+
+def test_get_line_type_missing():
+    sample_object = {"another-name": "SCHEMA"}
+    try:
+        get_line_type(sample_object, json.dumps(sample_object))
+        assert False
+    except Exception:
+        assert True

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,5 +1,18 @@
 import json
 from target_kinesis.target import *
+from mock import mock_open
+
+
+# emit_state
+
+
+def test_emit_state(capsys):
+    sample_state = {"limit": "50"}
+    emit_state(sample_state)
+    captured = capsys.readouterr()
+    assert captured.out != ""
+    assert captured.err == ""
+
 
 # decode_line
 
@@ -20,6 +33,7 @@ def test_decode_line_malformed():
     except json.decoder.JSONDecodeError:
         assert True
 
+
 # get_line_type
 
 
@@ -36,3 +50,145 @@ def test_get_line_type_missing():
         assert False
     except Exception:
         assert True
+
+
+# handle record
+
+
+def test_handle_record(mocker):
+    mocker.patch('target_kinesis.target.validate_record')
+    mocker.patch('target_kinesis.target.deliver_record')
+    result = handle_record({"stream": "a", "record": "b"}, {
+                           "a": {"field": "value"}}, "", {}, {})
+    assert result is None
+
+
+def test_handle_record_fail_on_missing_stream_name(mocker):
+    mocker.patch('target_kinesis.target.validate_record')
+    mocker.patch('target_kinesis.target.deliver_record')
+    try:
+        handle_record({"record": "b"}, {}, "", {}, {})
+        assert False
+    except Exception:
+        assert True
+
+
+def test_handle_record_fail_on_missing_schema(mocker):
+    mocker.patch('target_kinesis.target.validate_record')
+    mocker.patch('target_kinesis.target.deliver_record')
+    try:
+        handle_record({"stream": "a", "record": "b"}, {}, "", {}, {})
+        assert False
+    except Exception:
+        assert True
+
+
+# handle_state
+
+
+def test_handle_state():
+    sample_state = {"value": "1", "limit": "50"}
+    state = handle_state(sample_state)
+    assert state == sample_state["value"]
+
+
+# deliver_record
+
+
+def test_deliver_record_using_firehose(mocker):
+    mocked_setup = mocker.patch('target_kinesis.target.firehose_setup_client')
+    mocked_deliver = mocker.patch('target_kinesis.target.firehose_deliver')
+    sample_config = {
+        "is_firehose": True,
+        "stream_name": "sample-stream",
+    }
+    sample_records = []
+    deliver_record(sample_config, sample_records)
+    mocked_setup.assert_called_once()
+    mocked_deliver.assert_called_once()
+
+
+def test_deliver_record_using_kinesis(mocker):
+    mocked_setup = mocker.patch('target_kinesis.target.kinesis_setup_client')
+    mocked_deliver = mocker.patch('target_kinesis.target.kinesis_deliver')
+    sample_config = {
+        "is_firehose": False,
+        "stream_name": "sample-stream",
+        "partition_key": "id"
+    }
+    sample_records = []
+    deliver_record(sample_config, sample_records)
+    mocked_setup.assert_called_once()
+    mocked_deliver.assert_called_once()
+
+
+# load_config
+
+
+def test_load_config_empty_filename():
+    config = load_config("")
+    assert config == {}
+
+
+def test_load_config_from_file(mocker):
+    config_path = "path/to/open/sample.config.json"
+    mocked_open = mocker.patch(
+        'builtins.open', mock_open(read_data='{"data": "1"}'))
+    load_config(config_path)
+    mocked_open.assert_called_with(config_path)
+
+
+# persist_lines
+
+
+def test_persist_lines_empty_recordset():
+    state = persist_lines({}, [])
+    assert state is None
+
+
+def test_persist_lines_with_record(mocker):
+    records = ['{"type": "RECORD"}']
+    mocked_record = mocker.patch('target_kinesis.target.handle_record')
+    mocked_state=mocker.patch('target_kinesis.target.handle_state')
+    mocked_schema=mocker.patch('target_kinesis.target.handle_schema')
+    persist_lines({}, records)
+    mocked_record.assert_called_once()
+    mocked_state.assert_not_called()
+    mocked_schema.assert_not_called()
+
+
+def test_persist_lines_with_state(mocker):
+    records = ['{"type": "STATE"}']
+    mocked_record = mocker.patch('target_kinesis.target.handle_record')
+    mocked_state=mocker.patch('target_kinesis.target.handle_state')
+    mocked_schema=mocker.patch('target_kinesis.target.handle_schema')
+    persist_lines({}, records)
+    mocked_record.assert_not_called()
+    mocked_state.assert_called_once()
+    mocked_schema.assert_not_called()
+
+
+def test_persist_lines_with_schema(mocker):
+    records = ['{"type": "SCHEMA"}']
+    mocked_record = mocker.patch('target_kinesis.target.handle_record')
+    mocked_state=mocker.patch('target_kinesis.target.handle_state')
+    mocked_schema=mocker.patch('target_kinesis.target.handle_schema')
+    persist_lines({}, records)
+    mocked_record.assert_not_called()
+    mocked_state.assert_not_called()
+    mocked_schema.assert_called_once()
+
+
+def test_persist_lines_with_multiple_records(mocker):
+    records = [
+        '{"type": "SCHEMA"}',
+        '{"type": "RECORD"}',
+        '{"type": "STATE"}',
+    ]
+    mocked_record = mocker.patch('target_kinesis.target.handle_record')
+    mocked_state=mocker.patch('target_kinesis.target.handle_state')
+    mocked_schema=mocker.patch('target_kinesis.target.handle_schema')
+    persist_lines({}, records)
+    mocked_record.assert_called_once()
+    mocked_state.assert_called_once()
+    mocked_schema.assert_called_once()


### PR DESCRIPTION
Closes #6.

### Implementation details

The target reads from `stdin` (tap input) and filesystem (configuration files) and writes to Kinesis or Kinesis Firehose. In order to test most of the components, a bit of refactoring was required.

Most of the large functions were split into smaller chunks and the AWS section was refactored to move client outside the last method.

A few libraries were added:

- `pytest-mock` to mock functions
- `pytest-cov` for code coverage
- `moto` to mock `boto3`
